### PR TITLE
Fix no return statement in the non-void function (according g++8)

### DIFF
--- a/sidplayfp/src/menu.cpp
+++ b/sidplayfp/src/menu.cpp
@@ -442,4 +442,5 @@ const char* ConsolePlayer::getModel (SidTuneInfo::model_t model)
     case SidTuneInfo::SIDMODEL_ANY:
         return "ANY";
     }
+    return "";
 }


### PR DESCRIPTION
If the function is non-void, but no return, then when building with gcc8-c++, an incorrect assembler code is generated that falls in run-time. A more detailed description can be found here http://bugs.altlinux.org/36038.